### PR TITLE
Simple auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,15 @@ Note that both the `cdk deploy` and `cdk destroy` commands can be used to deploy
 - `cdk destroy` destroys the specified stack(s) from your default AWS account/region
 
 The `cdk.json` file tells the CDK Toolkit how to execute your app. The build step is not required when using JavaScript.
+
+The following script can be added to `package.json` to display the outputs from a stack in the terminal:
+
+```
+aws cloudformation describe-stacks --stack-name <YOUR_STACK_NAME> | jq '.Stacks | .[] | .Outputs | reduce .[] as $i ({}; .[$i.OutputKey] = $i.OutputValue)'
+```
+
+It seems that it's also possible to simply do the following (to be tested):
+
+```
+cdk deploy --outputs-file my-outputs.json
+```

--- a/lib/deploy-stack.js
+++ b/lib/deploy-stack.js
@@ -66,16 +66,12 @@ class Publisher extends cdk.Stack {
     });
 
     new cdk.CfnOutput(this, "apiId", {
-      description:
-        "This is the ID used to identified yourself when connecting with the River server.",
       value: this.id,
       exportName: "api-id",
     });
 
     new cdk.CfnOutput(this, "apiUrl", {
-      description:
-        "This is the url needed by your backend in order to publish events.",
-      value: httpApi.url + "/publish",
+      value: httpApi.url + "publish",
       exportName: "api-url",
     });
   }
@@ -93,9 +89,7 @@ class WebSocketServer extends cdk.Stack {
       "river-server",
       {
         taskImageOptions: {
-          image: ecs.ContainerImage.fromRegistry(
-            "catherinemond/river-demo-redis"
-          ),
+          image: ecs.ContainerImage.fromRegistry("catherinemond/debug-server"),
           environment: {
             APP_ID: `${this.id}`,
             REDIS_HOST: props.redis.cluster.attrRedisEndpointAddress,
@@ -114,26 +108,18 @@ class WebSocketServer extends cdk.Stack {
     riverService.service.connections.allowToDefaultPort(props.redis);
 
     new cdk.CfnOutput(this, "loadBalancerUrl", {
-      description:
-        "This is the url needed by your frontend app in order to establish the WS connection.",
       value: riverService.loadBalancer.loadBalancerDnsName,
     });
 
-    new cdk.CfnOutput(this, "loadBalancerId", {
-      description:
-        "This is the id needed by your frontend app in order to establish the WS connection.",
+    new cdk.CfnOutput(this, "secret", {
       value: this.id,
     });
 
     new cdk.CfnOutput(this, "apiUrl", {
-      description:
-        "This is the url needed by your backend in order to publish events.",
       value: cdk.Fn.importValue("api-url"),
     });
 
     new cdk.CfnOutput(this, "apiId", {
-      description:
-        "This is the ID used to identified yourself when connecting with the API.",
       value: cdk.Fn.importValue("api-id"),
     });
   }

--- a/lib/deploy-stack.js
+++ b/lib/deploy-stack.js
@@ -27,10 +27,16 @@ class SharedResources extends cdk.Stack {
   }
 }
 
-// Lambda function used to publish events from backend services
+// API Gateway + Lambda function used to publish events from backend services
 class Publisher extends cdk.Stack {
   constructor(parent, id, props) {
     super(parent, id, props);
+
+    // Create the HTTP API Gateway to handle POST requests
+    const httpApi = new apiGateway.HttpApi(this, "http-api");
+
+    // Save the api id as the unique identifier
+    this.id = httpApi.httpApiId;
 
     // Create the lambda responsible for publishing events
     const publisher = new lambda.Function(this, "publisher-lambda", {
@@ -40,6 +46,7 @@ class Publisher extends cdk.Stack {
       timeout: cdk.Duration.seconds(30),
       vpc: props.vpc,
       environment: {
+        API_ID: this.id,
         REDIS_HOST: props.redis.cluster.attrRedisEndpointAddress,
         REDIS_PORT: props.redis.cluster.attrRedisEndpointPort,
       },
@@ -52,13 +59,24 @@ class Publisher extends cdk.Stack {
       handler: publisher,
     });
 
-    // Create the HTTP API Gateway to handle POST requests
-    const httpApi = new apiGateway.HttpApi(this, "http-api");
-
     httpApi.addRoutes({
-      path: "/apps",
+      path: "/publish",
       methods: [apiGateway.HttpMethod.POST],
       integration: publisherIntegration,
+    });
+
+    new cdk.CfnOutput(this, "apiId", {
+      description:
+        "This is the ID used to identified yourself when connecting with the River server.",
+      value: this.id,
+      exportName: "api-id",
+    });
+
+    new cdk.CfnOutput(this, "apiUrl", {
+      description:
+        "This is the url needed by your backend in order to publish events.",
+      value: httpApi.url + "/publish",
+      exportName: "api-url",
     });
   }
 }
@@ -67,16 +85,19 @@ class WebSocketServer extends cdk.Stack {
   constructor(parent, id, props) {
     super(parent, id, props);
 
+    this.id = this.getLogicalId(this);
+
     // Create a load-balanced Fargate service and make it public
-    const realtimeServer = new ecs_patterns.ApplicationLoadBalancedFargateService(
+    const riverService = new ecs_patterns.ApplicationLoadBalancedFargateService(
       this,
-      "realtime-server",
+      "river-server",
       {
         taskImageOptions: {
           image: ecs.ContainerImage.fromRegistry(
             "catherinemond/river-demo-redis"
           ),
           environment: {
+            APP_ID: `${this.id}`,
             REDIS_HOST: props.redis.cluster.attrRedisEndpointAddress,
             REDIS_PORT: props.redis.cluster.attrRedisEndpointPort,
           },
@@ -90,7 +111,31 @@ class WebSocketServer extends cdk.Stack {
       }
     );
 
-    realtimeServer.service.connections.allowToDefaultPort(props.redis);
+    riverService.service.connections.allowToDefaultPort(props.redis);
+
+    new cdk.CfnOutput(this, "loadBalancerUrl", {
+      description:
+        "This is the url needed by your frontend app in order to establish the WS connection.",
+      value: riverService.loadBalancer.loadBalancerDnsName,
+    });
+
+    new cdk.CfnOutput(this, "loadBalancerId", {
+      description:
+        "This is the id needed by your frontend app in order to establish the WS connection.",
+      value: this.id,
+    });
+
+    new cdk.CfnOutput(this, "apiUrl", {
+      description:
+        "This is the url needed by your backend in order to publish events.",
+      value: cdk.Fn.importValue("api-url"),
+    });
+
+    new cdk.CfnOutput(this, "apiId", {
+      description:
+        "This is the ID used to identified yourself when connecting with the API.",
+      value: cdk.Fn.importValue("api-id"),
+    });
   }
 }
 
@@ -100,12 +145,12 @@ class RiverApp extends cdk.App {
 
     const sharedResources = new SharedResources(this, "shared-resources");
 
-    this.publisher = new Publisher(this, "publisher", {
+    const publisher = new Publisher(this, "publisher", {
       vpc: sharedResources.vpc,
       redis: sharedResources.redis,
     });
 
-    const wsServer = new WebSocketServer(this, "ws-server", {
+    const wsServer = new WebSocketServer(this, "river-server", {
       cluster: sharedResources.cluster,
       redis: sharedResources.redis,
     });


### PR DESCRIPTION
This branch includes a few changes, all in the `deploy-stack.js` file:

- clean up the code
- generate an API id and set it as an environment variable for the lambda
- generate a secret (based on the load balancer id) and set it as an environment variable for the container
- generate custom outputs with the information needed by the River user
  - API gateway address + API id used for basic server-side auth
  - load balancer address + secret used for JWT auth on the frontend

Note that the image used for the containers is now found in the following Docker Hub repo: catherinemond/debug-server

This has been tested with a simple create-react-app demo and is fully working.

Note that the lambda function hasn't yet been modified to authenticate the API id. This can be done in a separate step.
 