### PR TITLE
updated method for generating apikey and secret

### DIFF
--- a/lib/deploy-stack.js
+++ b/lib/deploy-stack.js
@@ -5,13 +5,14 @@ const ecs_patterns = require("@aws-cdk/aws-ecs-patterns");
 const apiGateway = require("@aws-cdk/aws-apigatewayv2");
 const lambda = require("@aws-cdk/aws-lambda");
 const redis = require("./redis");
+const { randomBytes } = require("crypto");
 
 // Stack holding all the shared resources
 class SharedResources extends cdk.Stack {
   constructor(scope, id, props) {
     super(scope, id, props);
 
-    // Create the network to run everything in
+    // Create the network to run everything i
     this.vpc = new ec2.Vpc(this, "river-vpc", {
       maxAzs: 2,
       natGateways: 1,
@@ -36,7 +37,7 @@ class Publisher extends cdk.Stack {
     const httpApi = new apiGateway.HttpApi(this, "http-api");
 
     // Create an api key as a unique identifier
-    this.id = this.getLogicalId(this);
+    this.id = randomBytes(16).toString("hex");
 
     // Create the lambda responsible for publishing events
     const publisher = new lambda.Function(this, "publisher-lambda", {
@@ -81,7 +82,7 @@ class WebSocketServer extends cdk.Stack {
   constructor(parent, id, props) {
     super(parent, id, props);
 
-    this.id = this.getLogicalId(this);
+    this.id = randomBytes(32).toString("hex");
 
     // Create a load-balanced Fargate service and make it public
     const riverService = new ecs_patterns.ApplicationLoadBalancedFargateService(


### PR DESCRIPTION
I change just two lines of code, using the node library `crypto` to generate a 128-bit apikey and a 256-bit secret.